### PR TITLE
Ability to view chat history

### DIFF
--- a/src/OpenAiManager.js
+++ b/src/OpenAiManager.js
@@ -57,7 +57,7 @@ class OpenAiManager {
    * @returns {Array<{ role: string, content: string }>} An array of messages for OpenAI.
    */
   _constructMessage(userPrompt, user) {
-    const previousChats = this._getUserChats(user);
+    const previousChats = this.getUserChats(user);
 
     const messages = [
       { role: "system", content: `Your name is ${this.name} and ${this.name} only. ` },
@@ -125,7 +125,7 @@ class OpenAiManager {
    * @param { string } user - username
    * @returns all the user chat history with the bot as a single string.
    */
-  _getUserChats(user = "default") {
+  getUserChats(user = "default") {
     return this._cache[user]
       ? Object.entries(this._cache[user])
           .map(([prompt, response]) => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -15,4 +15,26 @@ function parseUserMentionAndMessage(messageObj) {
 }
 
 
-module.exports = parseUserMentionAndMessage;
+/**
+ * Extracts all question-answer pairs from a chat history string.
+ * @param {string} chatHistory - The chat history string containing question-answer pairs.
+ * @returns {string[]} An array of question-answer pairs extracted from the chat history.
+ */
+function extractQuestionAnswerPairs(chatHistory) {
+    return chatHistory.split(/(?=Q:)/).filter(pair => pair.trim() !== "");
+}
+
+
+
+function changeStringToTitle(string) {
+    return string[0].toUpperCase() + string.slice(1);
+}
+
+
+
+// Exporting multiple variables or functions
+module.exports = {
+    changeStringToTitle,
+    extractQuestionAnswerPairs,
+    parseUserMentionAndMessage,
+};


### PR DESCRIPTION
Implement feature: Allow users to view their entire chat history

This commit implements a new feature where users can enter the command **!showMyChatHistory** to view their entire chat history. The feature includes functionality to fetch and display the user's chat history, including both prompts and questions sent to OpenAI. This enhances the usability of the bot by providing users with easy access to their chat history for reference and review.