### PR TITLE
Fixed the following issues

### DIFF
--- a/src/BotManager.js
+++ b/src/BotManager.js
@@ -166,8 +166,6 @@ async _moderateUserPrompt(content, message, isDirectMessage=false) {
   const moderations = await this._openAi.moderatePrompt(content);
   const messageContent = parseUserMentionAndMessage(content).messageContent;
 
-  this._showBotTyping(message);
-  
   if (moderations.length && !this._isTextInExcludeList(messageContent)) {
       
       this._sendWarningModerationMessage(moderations.join(", "), message.author, messageContent);

--- a/src/BotManager.js
+++ b/src/BotManager.js
@@ -25,7 +25,7 @@ class BotManager {
   constructor(discordBotToken, server_ID, openai_KEY) {
     /** @private */
     this.showHistoryCommand = "!showMyChatHistory";
-     /** @private */
+    /** @private */
     this._excludeArray = [this.showHistoryCommand];
     /** @private */
     this.strikeInterval = 3;
@@ -82,11 +82,11 @@ class BotManager {
    */
   _announcePresence() {
     const botName = this._client.user.displayName;
-   
-    const msg = `Hello everyone! I'm the **${botName}**, now online and ready to chat. To chat with me, ` + 
-            `**type @${botName} followed by your prompt**. ` +
-            `To see your history, **type @${botName} ${this.showHistoryCommand}** ` + 
-            `and to send a **DM (direct message)** to the user type **@<username>  followed by your message**`;
+
+    const msg = `Hello everyone! I'm the **${botName}**, now online and ready to chat. To chat with me, ` +
+      `**type @${botName} followed by your prompt**. ` +
+      `To see your history, **type @${botName} ${this.showHistoryCommand}** ` +
+      `and to send a **DM (direct message)** to the user type **@<username>  followed by your message**`;
 
     this._sendToChannel(this.defaultChannel, msg);;
   }
@@ -138,7 +138,7 @@ class BotManager {
 
 
     }
-  
+
     //  We don't send a message if:
     // - we sent the last message
     // - we haven't been mentioned in the last message
@@ -162,20 +162,20 @@ class BotManager {
  * @param {boolean} [isDirectMessage=false] - Flag indicating whether the content should be sent as a direct message to a user.
  * @returns {Promise<void>} - A Promise that resolves when the monitoring process is complete.
  */
-async _moderateUserPrompt(content, message, isDirectMessage=false) {
-  const moderations = await this._openAi.moderatePrompt(content);
-  const messageContent = parseUserMentionAndMessage(content).messageContent;
+  async _moderateUserPrompt(content, message, isDirectMessage = false) {
+    const moderations = await this._openAi.moderatePrompt(content);
+    const messageContent = parseUserMentionAndMessage(content).messageContent;
 
-  if (moderations.length && !this._isTextInExcludeList(messageContent)) {
+    if (moderations.length && !this._isTextInExcludeList(messageContent)) {
 
-    this._sendWarningModerationMessage(moderations.join(", "), message.author, messageContent);
-    return;
+      this._sendWarningModerationMessage(moderations.join(", "), message.author, messageContent);
+      return;
+    }
+
+    if (!isDirectMessage && !this._isTextInExcludeList(messageContent)) {
+      await this._queryOpenAi(messageContent, message)
+    };
   }
-
-  if (!isDirectMessage && !this._isTextInExcludeList(messageContent)) {
-    await this._queryOpenAi(messageContent, message)
-  };
-}
 
 
   /**
@@ -249,14 +249,14 @@ async _moderateUserPrompt(content, message, isDirectMessage=false) {
    * @param {Message} message - The Discord message object representing the message triggering the query.
    */
   async _queryOpenAi(prompt, message) {
-    
+
     this._showBotTyping(message);
     const waitMsg = await this._sendToChannel(
       this.defaultChannel,
       "Fetching response, please wait...."
     );
 
-    
+
     this._openAi.prompt(prompt, message.author.username).then((reply) => {
       if (!reply || (reply && !reply.length)) {
         this._sendToChannel(
@@ -265,7 +265,7 @@ async _moderateUserPrompt(content, message, isDirectMessage=false) {
         );
       }
 
-     
+
       this._sendToChannel(message.channel, `\n <@${message.author.id}> ${reply}`);
 
       waitMsg.delete(); // delete the message once the we get data or regardless whether we get the data
@@ -286,13 +286,13 @@ async _moderateUserPrompt(content, message, isDirectMessage=false) {
     const chatHistory = this._openAi.getUserHistory(message.author.username);
 
     this._showBotTyping(message);
-    
+
     // Check if there's no chat history available
     if (!chatHistory.length) {
       return await this._sendToChannel(this.defaultChannel, "There are no chats to view!");
     }
 
-  
+
     const loadingMessage = await this._sendToChannel(
       this.defaultChannel,
       `Fetching chat history from ${message.author.username}'s account...`
@@ -393,7 +393,7 @@ async _moderateUserPrompt(content, message, isDirectMessage=false) {
    * @param {Message} message - The message object representing the context of the command.
    * @returns {Promise<void>} - A Promise that resolves when the typing status is displayed.
   */
-  async  _showBotTyping(message) {
+  async _showBotTyping(message) {
     await message.channel.sendTyping();
   }
 

--- a/src/BotManager.js
+++ b/src/BotManager.js
@@ -166,7 +166,7 @@ class BotManager {
     const moderations = await this._openAi.moderatePrompt(content);
     const messageContent = parseUserMentionAndMessage(content).messageContent;
 
-    if (moderations.length && !this._isTextInExcludeList(messageContent)) {
+    if (moderations.length) {
 
       this._sendWarningModerationMessage(moderations.join(", "), message.author, messageContent);
       this._deleteMsg(message);

--- a/src/BotManager.js
+++ b/src/BotManager.js
@@ -169,6 +169,7 @@ class BotManager {
     if (moderations.length && !this._isTextInExcludeList(messageContent)) {
 
       this._sendWarningModerationMessage(moderations.join(", "), message.author, messageContent);
+      this._deleteMsg(message);
       return;
     }
 
@@ -406,6 +407,24 @@ class BotManager {
   _isTextInExcludeList(text) {
     return this._excludeArray.includes(text);
   }
+
+ /**
+ * Deletes a message and sends a reason to the default channel.
+ * @param {Message} message - The message object to delete.
+ * @param {string} [default string - reason="Your message has been deleted because it violates OpenAi rules"] .
+ */
+  _deleteMsg(message, reason = "Your message has been deleted because it violates OpenAi rules") {
+    if (message) {
+      message.delete()
+        .then(() => {
+          this._sendToChannel(this.defaultChannel, reason);
+        })
+        .catch((error) => {
+          console.error('Error deleting message:', error);
+        });
+    }
+  }
+
 
   get defaultChannel() {
     return this.guild && this.guild.id === this._serverID ? this.guild?.systemChannel : null;

--- a/src/BotManager.js
+++ b/src/BotManager.js
@@ -2,15 +2,19 @@ const {
   Client,
   GatewayIntentBits,
   Events,
-  EmbedBuilder,
   TextChannel,
   Message,
   GuildMember,
+  EmbedBuilder,
   User,
 } = require("discord.js");
 
 const OpenAiManager = require("./OpenAiManager");
 const { changeStringToTitle, parseUserMentionAndMessage } = require("./utils.js");
+
+const showHistoryCommand = "!showMyChatHistory";
+const strikeInterval = 3;
+const currentTimeNow = Date.now();
 
 /**
  * Represents a manager for a Discord bot, responsible for initializing the bot,
@@ -23,11 +27,6 @@ class BotManager {
    * @param {string} server_ID - The ID of the server where the bot will operate.
    */
   constructor(discordBotToken, server_ID, openai_KEY) {
-    /** @private */
-    this.showHistoryCommand = "!showMyChatHistory";
-    /** @private */
-    this.strikeInterval = 3;
-
     /** @private */
     this._client = new Client({
       intents: [
@@ -47,6 +46,7 @@ class BotManager {
     this._initialized = false;
     /** @private */
     this._lastMessageTime;
+
     /**@private */
     this._userStrikes = {};
 
@@ -80,13 +80,8 @@ class BotManager {
    */
   _announcePresence() {
     const botName = this._client.user.displayName;
-   
-    const msg = `Hello everyone! I'm the **${botName}**, now online and ready to chat. To chat with me, ` + 
-            `**type @${botName} followed by your prompt**. ` +
-            `To see your history, **type @${botName} ${this.showHistoryCommand}** ` + 
-            `and to send a **DM (direct message)** to the user type **@<username>  followed by your message**`;
-
-    this._sendToChannel(this.defaultChannel, msg);;
+    const msg = `Hello everyone! I'm the ${botName}, now online and ready to chat. To chat with me, type @${botName} followed by your prompt. To see your history, type @${botName} ${showHistoryCommand}.`;
+    this._sendToChannel(this.defaultChannel, msg);
   }
 
   /**
@@ -110,69 +105,33 @@ class BotManager {
     const content = message.content;
     const hasBeenMentioned = message.mentions.has(this._client.user.id);
     const isSameAuthor = author === this._client.application.id;
-    const currentTime = Date.now();
     const waitTimeLimit = 3000;
 
-    const hasTalkedRecently = this._lastMessageTime && currentTime - this._lastMessageTime < waitTimeLimit;
+    const hasTalkedRecently =
+      this._lastMessageTime && Date.now() - this._lastMessageTime < waitTimeLimit;
 
-    const { userId, messageContent } = parseUserMentionAndMessage(content);
-    const isDirectMessage = userId && messageContent;
-
-    if (author !== this._client.application.id) {
-     
-      this._moderateUserPrompt(content, message, isDirectMessage)
-      
-      switch(messageContent) {
-
-        case isDirectMessage:
-          this._sendDirectMessageToUser(userId, messageContent);
-          break;
-        
-        case (messageContent.trim() === this.showHistoryCommand):
-          this._showUserChatHistory(message, currentTime);
-          break;
-        
-      }
-                    
-    }
-  
     //  We don't send a message if:
     // - we sent the last message
     // - we haven't been mentioned in the last message
     // - we already replied in the last 3 seconds
-    //
-    // The line has to be at the bottom because if it is at the top, it prevents the other actions from executing.
-    // This is because it checks if the user has already been interacted with (talked to, mentioned, or talked to recently),
-    // and if so, the preceding if statement is not triggered. This means that the actions involving OpenAI, sending messages,
-    // and showing history are delayed until after a 3 seconds since there are not called because of the return statement.
     if (isSameAuthor || hasTalkedRecently || !hasBeenMentioned) {
       return;
     }
-
-  }
-
-  /**
- * Monitors user content for moderation and takes action accordingly.
- * 
- * @param {string} content - The content to monitor.
- * @param {Message} message - The message object representing the context of the command.
- * @param {boolean} [isDirectMessage=false] - Flag indicating whether the content should be sent as a direct message to a user.
- * @returns {Promise<void>} - A Promise that resolves when the monitoring process is complete.
- */
-async _moderateUserPrompt(content, message, isDirectMessage=false) {
-  const moderations = await this._openAi.moderatePrompt(content);
-  const messageContent = parseUserMentionAndMessage(content).messageContent;
-
-  if (moderations.length) {
-      this._sendWarningModerationMessage(moderations.join(", "), message.author, messageContent);
+    const { messageContent } = parseUserMentionAndMessage(content);
+    if (messageContent.trim() === showHistoryCommand) {
+      // checks for the phrase "!showMyChatHistory" in order to display the user's history
+      this._showUserChatHistory(message);
       return;
-  } 
+    }
 
-  // Query OpenAI only if the message is not intended to be sent as a DM (direct message).
-  if (!isDirectMessage) this._queryOpenAi(messageContent, message);
+    const moderations = await this._openAi.moderatePrompt(content);
 
-}
-
+    if (moderations.length) {
+      this._sendWarningModerationMessage(moderations.join(", "), message.author, messageContent);
+    } else {
+      this._queryOpenAi(messageContent, message);
+    }
+  }
 
   /**
    * Sends
@@ -198,14 +157,14 @@ async _moderateUserPrompt(content, message, isDirectMessage=false) {
 
     // if the user exceed the strike interval, and for every time they exceed it
     if (
-      this._userStrikes[username] > this.strikeInterval &&
-      this._userStrikes[username] % this.strikeInterval === 1
+      this._userStrikes[username] > strikeInterval &&
+      this._userStrikes[username] % strikeInterval === 1
     ) {
       const member = await this.guild.members.fetch({ user });
       try {
         // increments the time the user is timed out for depending of how many strikes they have.
         // but it doesn't exceed one hour.
-        const timeoutDuration = Math.min(this.strikeInterval ** 2 * 1000, 3600 * 1000);
+        const timeoutDuration = Math.min(strikeInterval ** 2 * 1000, 3600 * 1000);
         await member.timeout(timeoutDuration, "Violating speech terms.");
       } catch (e) {
         console.error(
@@ -245,14 +204,10 @@ async _moderateUserPrompt(content, message, isDirectMessage=false) {
    * @param {Message} message - The Discord message object representing the message triggering the query.
    */
   async _queryOpenAi(prompt, message) {
-    
-    this._showBotTyping(message);
     const waitMsg = await this._sendToChannel(
       this.defaultChannel,
       "Fetching response, please wait...."
     );
-
-    
     this._openAi.prompt(prompt, message.author.username).then((reply) => {
       if (!reply || (reply && !reply.length)) {
         this._sendToChannel(
@@ -261,7 +216,6 @@ async _moderateUserPrompt(content, message, isDirectMessage=false) {
         );
       }
 
-     
       this._sendToChannel(message.channel, `\n <@${message.author.id}> ${reply}`);
 
       waitMsg.delete(); // delete the message once the we get data or regardless whether we get the data
@@ -274,27 +228,22 @@ async _moderateUserPrompt(content, message, isDirectMessage=false) {
    * Users can request their entire chat history by issuing the command "!showMyChatHistory" in Discord.
    *
    * @param {Message} message The message object representing the command invocation.
-   * @param {number} currentTime the current time
    * @returns {Promise<void>} A promise that resolves once the chat history is displayed.
    */
-  async _showUserChatHistory(message, currentTime) {
-
+  async _showUserChatHistory(message) {
     const chatHistory = this._openAi.getUserHistory(message.author.username);
 
-    this._showBotTyping(message);
-    
     // Check if there's no chat history available
     if (!chatHistory.length) {
       return await this._sendToChannel(this.defaultChannel, "There are no chats to view!");
     }
 
-  
     const loadingMessage = await this._sendToChannel(
       this.defaultChannel,
       `Fetching chat history from ${message.author.username}'s account...`
     );
 
-    const popupEmbed = await this._createEmbeddedChatHistory(chatHistory, message, currentTime);
+    const popupEmbed = await this._createEmbeddedChatHistory(chatHistory, message);
     await loadingMessage.edit({ content: "Here is your chat history:", embeds: [popupEmbed] });
   }
 
@@ -302,10 +251,9 @@ async _moderateUserPrompt(content, message, isDirectMessage=false) {
    * Creates an embedded representation of the provided chat history.
    * @param {string[][]} chatHistory The chat history to be embedded.
    * @param {Message} message The message object used for context, such as the author's username.
-   * @param {number} currentTime the current time
    * @returns {Promise<MessageEmbed>} A promise that resolves with the embedded chat history.
    */
-  async _createEmbeddedChatHistory(chatHistory, message, currentTime) {
+  async _createEmbeddedChatHistory(chatHistory, message) {
     // Extract question-answer pairs from the chat history
     const fields = this._generateFieldsFromQAPairs(chatHistory);
 
@@ -314,7 +262,7 @@ async _moderateUserPrompt(content, message, isDirectMessage=false) {
       .setTitle("User Chat History")
       .setAuthor({ name: `Bot name: ${this._openAi.name}` })
       .setColor("DarkRed")
-      .setTimestamp(currentTime)
+      .setTimestamp(currentTimeNow)
       .setFooter({ text: message.author.username })
       .addFields(fields);
 
@@ -335,7 +283,7 @@ async _moderateUserPrompt(content, message, isDirectMessage=false) {
       // Create an object representing a field and push it to the fields array
       fields.push({
         name: `Q:  ${changeStringToTitle(question)}`,
-        value: `**A: **  ${answer}`,
+        value: `A:  ${answer}`,
         inline: false,
       });
 
@@ -381,16 +329,6 @@ async _moderateUserPrompt(content, message, isDirectMessage=false) {
 
       return "";
     }
-  }
-
-  /**
-   * Asynchronously displays typing status for the bot in the given message's channel.
-   * 
-   * @param {Message} message - The message object representing the context of the command.
-   * @returns {Promise<void>} - A Promise that resolves when the typing status is displayed.
-  */
-  async  _showBotTyping(message) {
-    await message.channel.sendTyping();
   }
 
   get defaultChannel() {

--- a/src/BotManager.js
+++ b/src/BotManager.js
@@ -25,8 +25,8 @@ class BotManager {
   constructor(discordBotToken, server_ID, openai_KEY) {
     /** @private */
     this.showHistoryCommand = "!showMyChatHistory";
-     /** @private */
-     this._excludeArray = [this.showHistoryCommand];
+    /** @private */
+    this._excludeArray = [this.showHistoryCommand];
     /** @private */
     this.strikeInterval = 3;
 
@@ -82,11 +82,11 @@ class BotManager {
    */
   _announcePresence() {
     const botName = this._client.user.displayName;
-   
-    const msg = `Hello everyone! I'm the **${botName}**, now online and ready to chat. To chat with me, ` + 
-            `**type @${botName} followed by your prompt**. ` +
-            `To see your history, **type @${botName} ${this.showHistoryCommand}** ` + 
-            `and to send a **DM (direct message)** to the user type **@<username>  followed by your message**`;
+
+    const msg = `Hello everyone! I'm the **${botName}**, now online and ready to chat. To chat with me, ` +
+      `**type @${botName} followed by your prompt**. ` +
+      `To see your history, **type @${botName} ${this.showHistoryCommand}** ` +
+      `and to send a **DM (direct message)** to the user type **@<username>  followed by your message**`;
 
     this._sendToChannel(this.defaultChannel, msg);;
   }
@@ -108,36 +108,36 @@ class BotManager {
    * @private
    */
   async _onMessageCreate(message) {
-    const author                   = message.author.id;
-    const content                  = message.content;
-    const hasBeenMentioned         = message.mentions.has(this._client.user.id);
-    const isSameAuthor             = author === this._client.application.id;
-    const currentTime              = Date.now();
-    const waitTimeLimit            = 3000;
-    const hasTalkedRecently        = this._lastMessageTime && currentTime - this._lastMessageTime < waitTimeLimit;
+    const author = message.author.id;
+    const content = message.content;
+    const hasBeenMentioned = message.mentions.has(this._client.user.id);
+    const isSameAuthor = author === this._client.application.id;
+    const currentTime = Date.now();
+    const waitTimeLimit = 3000;
+    const hasTalkedRecently = this._lastMessageTime && currentTime - this._lastMessageTime < waitTimeLimit;
     let { userId, messageContent } = parseUserMentionAndMessage(content);
-    let isDirectMessage            = (userId != this._client.application.id && messageContent && !this._isTextInExcludeList(messageContent));
-     
-  
+    let isDirectMessage = (userId != this._client.application.id && messageContent && !this._isTextInExcludeList(messageContent));
+
+
     if (author !== this._client.application.id) {
-      
+
       this._moderateUserPrompt(content, message, isDirectMessage);
 
-      switch(true) {
+      switch (true) {
 
         case isDirectMessage:
           this._sendDirectMessageToUser(userId, messageContent);
           break;
-        
+
         case (messageContent.trim() === this.showHistoryCommand):
           await this._showUserChatHistory(message, currentTime);
-          break;          
-                  
+          break;
+
       }
-     
-                    
+
+
     }
-  
+
     //  We don't send a message if:
     // - we sent the last message
     // - we haven't been mentioned in the last message
@@ -161,22 +161,22 @@ class BotManager {
  * @param {boolean} [isDirectMessage=false] - Flag indicating to not send the message to openAi if the message is a DM.
  * @returns {Promise<void>} - A Promise that resolves when the monitoring process is complete.
  */
-async _moderateUserPrompt(content, message, isDirectMessage=false) {
+  async _moderateUserPrompt(content, message, isDirectMessage = false) {
 
-  const moderations = await this._openAi.moderatePrompt(content);
-  const messageContent = parseUserMentionAndMessage(content).messageContent;
+    const moderations = await this._openAi.moderatePrompt(content);
+    const messageContent = parseUserMentionAndMessage(content).messageContent;
 
-  if (moderations.length && !this._isTextInExcludeList(messageContent)) {
-      
+    if (moderations.length && !this._isTextInExcludeList(messageContent)) {
+
       this._sendWarningModerationMessage(moderations.join(", "), message.author, messageContent);
       return;
-  } 
+    }
 
-  if (!isDirectMessage && !this._isTextInExcludeList(messageContent)) {
-    await this._queryOpenAi(messageContent, message)
-  };
+    if (!isDirectMessage && !this._isTextInExcludeList(messageContent)) {
+      await this._queryOpenAi(messageContent, message)
+    };
 
-}
+  }
 
 
   /**
@@ -231,7 +231,7 @@ async _moderateUserPrompt(content, message, isDirectMessage=false) {
     if (!user) {
       console.log(`User with ID ${userID} does not exist.`);
       return;
-    } 
+    }
 
     user.send(message)
       .then(() => {
@@ -249,14 +249,14 @@ async _moderateUserPrompt(content, message, isDirectMessage=false) {
    * @param {Message} message - The Discord message object representing the message triggering the query.
    */
   async _queryOpenAi(prompt, message) {
-    
+
     this._showBotTyping(message);
     const waitMsg = await this._sendToChannel(
       this.defaultChannel,
       "Fetching response, please wait...."
     );
 
-    
+
     this._openAi.prompt(prompt, message.author.username).then((reply) => {
       if (!reply || (reply && !reply.length)) {
         this._sendToChannel(
@@ -265,7 +265,7 @@ async _moderateUserPrompt(content, message, isDirectMessage=false) {
         );
       }
 
-     
+
       this._sendToChannel(message.channel, `\n <@${message.author.id}> ${reply}`);
 
       waitMsg.delete(); // delete the message once the we get data or regardless whether we get the data
@@ -286,13 +286,13 @@ async _moderateUserPrompt(content, message, isDirectMessage=false) {
     const chatHistory = this._openAi.getUserHistory(message.author.username);
 
     this._showBotTyping(message);
-    
+
     // Check if there's no chat history available
     if (!chatHistory.length) {
       return await this._sendToChannel(this.defaultChannel, "There are no chats to view!");
     }
 
-  
+
     const loadingMessage = await this._sendToChannel(
       this.defaultChannel,
       `Fetching chat history from ${message.author.username}'s account...`
@@ -387,12 +387,12 @@ async _moderateUserPrompt(content, message, isDirectMessage=false) {
     }
   }
 
-/**
- * Checks if a given text is included in the exclusion list.
- * 
- * @param {string} text - The text to check against the exclusion list.
- * @returns {boolean} - Returns true if the text is found in the exclusion list, false otherwise.
- */
+  /**
+   * Checks if a given text is included in the exclusion list.
+   * 
+   * @param {string} text - The text to check against the exclusion list.
+   * @returns {boolean} - Returns true if the text is found in the exclusion list, false otherwise.
+   */
   _isTextInExcludeList(text) {
     return this._excludeArray.includes(text);
   }
@@ -403,7 +403,7 @@ async _moderateUserPrompt(content, message, isDirectMessage=false) {
    * @param {Message} message - The message object representing the context of the command.
    * @returns {Promise<void>} - A Promise that resolves when the typing status is displayed.
   */
-  async  _showBotTyping(message) {
+  async _showBotTyping(message) {
     await message.channel.sendTyping();
   }
 


### PR DESCRIPTION
**Issue Summary:**

The Discord bot lost its ability to send direct messages to users after gaining a new cool feature to listen to all prompts and check for violations. This issue has been resolved.

**Resolution:**

After restoring its ability to send direct messages, the Discord bot encountered a problem processing commands that allowed users to view their past chats with OpenAI and ask the bot questions. This occurred because the commands to view chat history and ask questions were being sent as direct messages. The root cause was that the command structure for sending direct messages, asking questions to the bot, and viewing previous chats was identical, differing only in the command name. For example, to send a message to a user:

Command to send a message:

- bot name followed by the message

Command to view chat history:

-  bot name followed by the command

Command to ask the bot a question:

- bot name followed by the question to ask


This resulted in the bot treating all commands as direct messages.

**Issue Resolution:**
The problem has been fixed.


**New Issue:**

After resolving the initial issues, a new problem emerged: the bot started querying the openAi after each command was executed. For instance, if a user sent a message to another user, the message was sent, and then the result was queried and displayed on the screen. The same occurred when requesting chat history. The chat history was displayed as requested, followed by a message stating that as an OpenAI bot, it could not retrieve user chats.

**Fixed:**
All mentioned issues have been resolved.

1. Users can now send direct messages without their messages being queried.
2. Users can request to view their chat history without their requests being queried.

**New feature added**

Added the ability for the bot to automatically delete speech that violates it terms and conditions.