### PR TITLE
Fixed bot not finding general channel after deleted & recreated

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "nodemon src/index.js",
+    "start-once": "node src/index.js",
     "test": "node --test tests/mainTestFile.js",
     "test-openai": "nodemon --test tests/openAi/openai.test.js"
   },


### PR DESCRIPTION
I wanted to clear the bot's chat history, so I deleted the general channel & made it again only to find that it couldn't find the general channel again.

I found the issue to be that guild systemChannel property was set to null, so now we're looping through all the channels until we're finding the one called 'general' & sending our messages there.

But also now, instead of sending all messages to the general channel, we check from which channel the message was sent from & attempt ot send it there instead, so if the bot is @mentioned in another channel, it responds there

